### PR TITLE
Fix: Failure to pass service to execute-job

### DIFF
--- a/bigquery/src/clojure/gclouj/bigquery.clj
+++ b/bigquery/src/clojure/gclouj/bigquery.clj
@@ -400,4 +400,4 @@
         (.destinationTable builder (TableId/of project-id dataset-id table-id))))
     (when-not (nil? dry-run?)
       (.dryRun builder dry-run?))
-    (execute-job (.build builder))))
+    (execute-job service (.build builder))))


### PR DESCRIPTION
Fix issue with query-job where it failed because the arity for execute-job was wrong.